### PR TITLE
fix alt for decorative image

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -45,4 +45,4 @@
 	{{ else }}
 	src="{{ $src.Permalink }}" 
 	{{ end }}
-	{{ with .Get "alt" }}alt='{{.}}'{{ end }}>
+	{{- with .Get "alt" -}}alt="{{.}}"{{ else }}alt=""{{- end -}}


### PR DESCRIPTION
A little fix for alt="" on the shortcode.
https://www.w3.org/WAI/tutorials/images/decorative/